### PR TITLE
fix ac_model being bytes and break recorder

### DIFF
--- a/custom_components/climate/xiaomi_miio.py
+++ b/custom_components/climate/xiaomi_miio.py
@@ -203,7 +203,7 @@ class XiaomiAirConditioningCompanion(ClimateDevice):
             self._available = True
             self._state = state.is_on
             self._state_attrs.update({
-                ATTR_AIR_CONDITION_MODEL: state.air_condition_model,
+                ATTR_AIR_CONDITION_MODEL: state.air_condition_model.hex(),
                 ATTR_LOAD_POWER: state.load_power,
                 ATTR_TEMPERATURE: state.target_temperature,
                 ATTR_SWING_MODE: state.swing_mode.name,


### PR DESCRIPTION
`state.air_condition_model` is currently return a bytes, which break recorder with  
`2018-06-26 00:09:40 ERROR (Recorder) [homeassistant.components.recorder.util] Error executing query: Object of type 'bytes' is not JSON serializable`

I think it should return its hex representation, which is used by its logger.