### PR TITLE
Fix _async_sensor_changed signature and implementation bug 

### DIFF
--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -297,8 +297,11 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
         else:
             await self.async_turn_off()
 
-    async def _async_sensor_changed(self, entity_id, old_state, new_state):
+    async def _async_sensor_changed(self, event):
         """Handle temperature changes."""
+        entity_id = event.data["entity_id"]
+        old_state = event.data["old_state"]
+        new_state = event.data["new_state"]
         if new_state is None:
             return
         self._async_update_temp(new_state)

--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -299,8 +299,6 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
 
     async def _async_sensor_changed(self, event):
         """Handle temperature changes."""
-        entity_id = event.data["entity_id"]
-        old_state = event.data["old_state"]
         new_state = event.data["new_state"]
         if new_state is None:
             return


### PR DESCRIPTION
Fix _async_sensor_changed signature and implementation bug  introduced in 38b9c6e36cd020452de3f455b084de9b3de85118.

For further reference, see https://developers.home-assistant.io/blog/2024/04/13/deprecate_async_track_state_change/