### PR TITLE
Fix: AttributeError 'HomeAssistant' object has no attribute 'components'otification

### DIFF
--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -316,7 +316,9 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
         from miio import DeviceException
 
         try:
-            result = await self.hass.async_add_executor_job(partial(func, *args, **kwargs))
+            result = await self.hass.async_add_executor_job(
+                partial(func, *args, **kwargs)
+            )
 
             _LOGGER.debug("Response received: %s", result)
 
@@ -561,7 +563,9 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
                 _LOGGER.info(log_msg)
                 self.hass.async_create_task(
                     self.hass.services.async_call(
-                        "persistent_notification", "create", {"message": log_msg, "title": "Xiaomi Miio Remote"}
+                        "persistent_notification",
+                        "create",
+                        {"message": log_msg, "title": "Xiaomi Miio Remote"},
                     )
                 )
                 await self.hass.async_add_executor_job(self._device.learn_stop, slot)
@@ -573,7 +577,12 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
         _LOGGER.error("Timeout. No infrared command captured")
         self.hass.async_create_task(
             self.hass.services.async_call(
-                "persistent_notification", "create", {"message": "Timeout. No infrared command captured", "title": "Xiaomi Miio Remote"}
+                "persistent_notification",
+                "create",
+                {
+                    "message": "Timeout. No infrared command captured",
+                    "title": "Xiaomi Miio Remote",
+                },
             )
         )
 

--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -559,8 +559,10 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
             if message.startswith("FE"):
                 log_msg = "Received command is: {}".format(message)
                 _LOGGER.info(log_msg)
-                self.hass.components.persistent_notification.async_create(
-                    log_msg, title="Xiaomi Miio Remote"
+                self.hass.async_create_task(
+                    self.hass.services.async_call(
+                        "persistent_notification", "create", {"message": log_msg, "title": "Xiaomi Miio Remote"}
+                    )
                 )
                 await self.hass.async_add_executor_job(self._device.learn_stop, slot)
                 return

--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -571,8 +571,10 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
 
         await self.hass.async_add_executor_job(self._device.learn_stop, slot)
         _LOGGER.error("Timeout. No infrared command captured")
-        self.hass.components.persistent_notification.async_create(
-            "Timeout. No infrared command captured", title="Xiaomi Miio Remote"
+        self.hass.async_create_task(
+            self.hass.services.async_call(
+                "persistent_notification", "create", {"message": "Timeout. No infrared command captured", "title": "Xiaomi Miio Remote"}
+            )
         )
 
     async def async_send_command(self, command, **kwargs):


### PR DESCRIPTION
In newer versions of Home Assistant, the legacy way of calling component services directly on self.hass.components is being deprecated, leading to the following error: AttributeError: 'HomeAssistant' object has no attribute 'components' This PR ensures the integration remains functional for all users.