### PR TITLE
Apply configured LED state consistently on turn_on

### DIFF
--- a/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
+++ b/custom_components/xiaomi_miio_airconditioningcompanion/climate.py
@@ -342,6 +342,11 @@ class XiaomiAirConditioningCompanion(ClimateEntity):
 
         if result:
             self._state = True
+            # A plain power-on command doesn't carry the LED flag, unlike
+            # _send_configuration(). Re-send the full configuration so the
+            # configured LED state is applied consistently regardless of
+            # how the AC was turned on.
+            await self._send_configuration()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the miio device off."""


### PR DESCRIPTION
## Problem

#180 added a `led` config option so the panel LED state is applied on
every configuration change (temperature/mode/fan/swing), but
`async_turn_on()` only calls the bare power-on command and never
re-sends the configuration. So the configured `led` value is not
applied when the AC is turned on via the plain toggle (e.g.
`climate.turn_on`) instead of a mode/temperature change.

## Solution

Re-send the full configuration (which includes the `led` value) right
after a successful power-on, so the LED state is applied consistently
regardless of how the AC is turned on.

## Testing

Verified on a real Aqara AC Companion: toggling `climate.turn_on`
directly now applies the configured LED state, matching the behavior
already present when changing temperature/mode/fan/swing.